### PR TITLE
Add deterministic audio chunking component

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .ffmpeg import FfmpegAdapter, build_ffmpeg_chunk_cmd, build_ffmpeg_normalize_cmd
+
+__all__ = [
+    "FfmpegAdapter",
+    "build_ffmpeg_normalize_cmd",
+    "build_ffmpeg_chunk_cmd",
+]

--- a/src/adapters/ffmpeg.py
+++ b/src/adapters/ffmpeg.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from os import PathLike
+from pathlib import Path
+from typing import Protocol
+
+
+type StrPath = str | PathLike[str]
+
+
+def _path_str(value: StrPath) -> str:
+    return str(Path(value))
+
+
+def _require_positive_int(name: str, value: int) -> None:
+    if value <= 0:
+        raise ValueError(f"{name} must be > 0")
+
+
+def build_ffmpeg_normalize_cmd(
+    input_path: StrPath,
+    output_path: StrPath,
+    sample_rate: int = 16000,
+    channels: int = 1,
+) -> list[str]:
+    """Build a deterministic ffmpeg command for PCM WAV normalization."""
+    _require_positive_int("sample_rate", sample_rate)
+    _require_positive_int("channels", channels)
+
+    return [
+        "ffmpeg",
+        "-y",
+        "-i",
+        _path_str(input_path),
+        "-vn",
+        "-acodec",
+        "pcm_s16le",
+        "-ar",
+        str(sample_rate),
+        "-ac",
+        str(channels),
+        _path_str(output_path),
+    ]
+
+
+def build_ffmpeg_chunk_cmd(
+    input_audio: StrPath,
+    chunks_dir: StrPath,
+    chunk_seconds: int,
+) -> list[str]:
+    """Build a deterministic ffmpeg segmenting command for chunked WAV output."""
+    _require_positive_int("chunk_seconds", chunk_seconds)
+    chunk_pattern = Path(chunks_dir) / "chunk_%04d.wav"
+
+    return [
+        "ffmpeg",
+        "-y",
+        "-i",
+        _path_str(input_audio),
+        "-f",
+        "segment",
+        "-segment_time",
+        str(chunk_seconds),
+        "-reset_timestamps",
+        "1",
+        "-map",
+        "0:a:0",
+        "-c",
+        "copy",
+        str(chunk_pattern),
+    ]
+
+
+class FfmpegAdapter(Protocol):
+    def chunk_audio(self, input_audio: StrPath, chunks_dir: StrPath, chunk_seconds: int) -> None:
+        """Split normalized audio into chunked WAV files."""
+
+
+__all__ = [
+    "FfmpegAdapter",
+    "build_ffmpeg_normalize_cmd",
+    "build_ffmpeg_chunk_cmd",
+]

--- a/src/components/chunking.py
+++ b/src/components/chunking.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+from src.adapters.ffmpeg import FfmpegAdapter
+from src.contracts.artifacts import AudioArtifact, ChunksArtifact
+from src.contracts.errors import ChunkingError, InputValidationError
+
+
+_CHUNK_NAME_RE = re.compile(r"^chunk_(\d{4})\.wav$")
+
+
+def _validate_chunk_seconds(chunk_seconds: int) -> None:
+    if chunk_seconds <= 0:
+        raise InputValidationError("chunk_seconds must be > 0")
+
+
+def _validate_input_audio(normalized_audio: AudioArtifact) -> None:
+    if not normalized_audio.path.exists():
+        raise InputValidationError(f"normalized audio not found: {normalized_audio.path}")
+    if not normalized_audio.path.is_file():
+        raise InputValidationError(f"normalized audio is not a file: {normalized_audio.path}")
+
+
+def _prepare_out_dir(out_dir: Path) -> Path:
+    out_dir = Path(out_dir)
+    if out_dir.exists() and any(out_dir.iterdir()):
+        raise ChunkingError(f"chunk output directory must be empty: {out_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _collect_chunk_paths(out_dir: Path) -> list[Path]:
+    chunk_paths = sorted(path for path in out_dir.iterdir() if path.is_file())
+    if not chunk_paths:
+        raise ChunkingError(f"ffmpeg produced no chunk files in {out_dir}")
+
+    indices: list[int] = []
+    for path in chunk_paths:
+        match = _CHUNK_NAME_RE.fullmatch(path.name)
+        if match is None:
+            raise ChunkingError(f"unexpected chunk filename: {path.name}")
+        indices.append(int(match.group(1)))
+
+    expected_indices = list(range(len(indices)))
+    if indices != expected_indices:
+        raise ChunkingError(
+            f"chunk filenames must be contiguous and zero-based in {out_dir}"
+        )
+    return chunk_paths
+
+
+def chunk_audio(
+    normalized_audio: AudioArtifact,
+    chunk_seconds: int,
+    out_dir: Path,
+    ffmpeg: FfmpegAdapter,
+) -> ChunksArtifact:
+    _validate_chunk_seconds(chunk_seconds)
+    _validate_input_audio(normalized_audio)
+    out_dir = _prepare_out_dir(out_dir)
+
+    ffmpeg.chunk_audio(normalized_audio.path, out_dir, chunk_seconds)
+    chunk_paths = _collect_chunk_paths(out_dir)
+
+    return ChunksArtifact(
+        dir=out_dir,
+        chunk_paths=chunk_paths,
+        chunk_seconds=chunk_seconds,
+        count=len(chunk_paths),
+    )
+
+
+__all__ = ["chunk_audio"]

--- a/tests/test_chunking_paths.py
+++ b/tests/test_chunking_paths.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from src.components.chunking import chunk_audio
+from src.contracts.artifacts import AudioArtifact
+from src.contracts.errors import ChunkingError, InputValidationError
+
+
+class _FakeFfmpeg:
+    def __init__(self, files_to_write: list[str]) -> None:
+        self.files_to_write = files_to_write
+        self.calls: list[tuple[Path, Path, int]] = []
+
+    def chunk_audio(self, input_audio: str | Path, chunks_dir: str | Path, chunk_seconds: int) -> None:
+        input_path = Path(input_audio)
+        out_dir = Path(chunks_dir)
+        self.calls.append((input_path, out_dir, chunk_seconds))
+        for name in self.files_to_write:
+            (out_dir / name).write_bytes(b"wav")
+
+
+class ChunkAudioPathTests(unittest.TestCase):
+    def test_returns_sorted_chunk_paths_and_count(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            normalized = root / "normalized.wav"
+            normalized.write_bytes(b"wav")
+            out_dir = root / "chunks"
+            ffmpeg = _FakeFfmpeg(["chunk_0002.wav", "chunk_0000.wav", "chunk_0001.wav"])
+
+            artifact = chunk_audio(
+                normalized_audio=AudioArtifact(path=normalized, sha256="0" * 64),
+                chunk_seconds=30,
+                out_dir=out_dir,
+                ffmpeg=ffmpeg,
+            )
+
+            self.assertEqual(ffmpeg.calls, [(normalized, out_dir, 30)])
+            self.assertEqual(artifact.dir, out_dir)
+            self.assertEqual(artifact.chunk_seconds, 30)
+            self.assertEqual(artifact.count, 3)
+            self.assertEqual(
+                artifact.chunk_paths,
+                [
+                    out_dir / "chunk_0000.wav",
+                    out_dir / "chunk_0001.wav",
+                    out_dir / "chunk_0002.wav",
+                ],
+            )
+
+    def test_rejects_missing_normalized_audio(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self.assertRaises(InputValidationError):
+                chunk_audio(
+                    normalized_audio=AudioArtifact(path=root / "missing.wav", sha256="0" * 64),
+                    chunk_seconds=30,
+                    out_dir=root / "chunks",
+                    ffmpeg=_FakeFfmpeg(["chunk_0000.wav"]),
+                )
+
+    def test_rejects_non_contiguous_chunk_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            normalized = root / "normalized.wav"
+            normalized.write_bytes(b"wav")
+
+            with self.assertRaises(ChunkingError):
+                chunk_audio(
+                    normalized_audio=AudioArtifact(path=normalized, sha256="0" * 64),
+                    chunk_seconds=30,
+                    out_dir=root / "chunks",
+                    ffmpeg=_FakeFfmpeg(["chunk_0000.wav", "chunk_0002.wav"]),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

### Summary

This PR introduces the audio chunking component and associated contract tests.

It enforces deterministic chunk naming, strict ordering guarantees, and clean adapter-based separation of ffmpeg execution.

---

## What Changed

### Added

- `chunk_audio(...) -> ChunksArtifact` in `src/components/chunking.py`
- `FfmpegAdapter` protocol type in `ffmpeg.py`
- Exported `FfmpegAdapter` via `__init__.py`
- Path + ordering contract tests in `tests/test_chunking_paths.py`

---

## `chunk_audio` Behavior

### Validation

- Validates `chunk_seconds > 0`
- Validates `normalized_audio.path` exists and is a file
- Requires `out_dir` to be empty (fails fast otherwise)
- Creates `out_dir` if it does not exist

### Execution

- Calls `ffmpeg.chunk_audio(...)` via adapter
- Does not construct shell commands directly
- No orchestration logic present

### Chunk Collection

- Discovers chunk files deterministically
- Sorted lexicographically
- Enforces strict contiguous naming:
