### PR TITLE
Add transcription provider abstraction and normalize transcripts

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 from .ffmpeg import FfmpegAdapter, build_ffmpeg_chunk_cmd, build_ffmpeg_normalize_cmd
+from .openai_transcription import OpenAIClientLike, OpenAITranscriptionAdapter
+from .transcription import TranscriptionProvider
 
 __all__ = [
     "FfmpegAdapter",
     "build_ffmpeg_normalize_cmd",
     "build_ffmpeg_chunk_cmd",
+    "TranscriptionProvider",
+    "OpenAIClientLike",
+    "OpenAITranscriptionAdapter",
 ]

--- a/src/adapters/openai_transcription.py
+++ b/src/adapters/openai_transcription.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from src.adapters.transcription import TranscriptionProvider
+from src.contracts.artifacts import ChunksArtifact, TranscriptArtifact, TranscriptSegment
+from src.contracts.errors import ProviderResponseError, ProviderRetryExhaustedError
+
+
+class _OpenAITranscriptionsAPI(Protocol):
+    def create(self, **kwargs: Any) -> Any: ...
+
+
+class _OpenAIAudioAPI(Protocol):
+    transcriptions: _OpenAITranscriptionsAPI
+
+
+class OpenAIClientLike(Protocol):
+    audio: _OpenAIAudioAPI
+
+
+@dataclass(frozen=True, slots=True)
+class _NormalizedChunkTranscript:
+    text: str
+    language: str | None
+    duration_s: float | None
+    segments: list[TranscriptSegment]
+
+
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    if hasattr(obj, name):
+        return getattr(obj, name)
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump()
+        if isinstance(dumped, dict):
+            return dumped.get(name, default)
+    return default
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalize_segments(raw_segments: Any) -> list[TranscriptSegment]:
+    if raw_segments in (None, ""):
+        return []
+    if not isinstance(raw_segments, list):
+        raise ProviderResponseError("OpenAI transcription 'segments' must be a list when provided")
+
+    segments: list[TranscriptSegment] = []
+    for idx, raw in enumerate(raw_segments):
+        text = _coerce_text(_field(raw, "text"))
+        start_s = _float_or_none(_field(raw, "start"))
+        end_s = _float_or_none(_field(raw, "end"))
+        if not text and start_s is None and end_s is None:
+            continue
+        segments.append(
+            TranscriptSegment(
+                index=idx,
+                text=text,
+                start_s=start_s,
+                end_s=end_s,
+            )
+        )
+    return segments
+
+
+class OpenAITranscriptionAdapter(TranscriptionProvider):
+    """OpenAI-only provider adapter that normalizes responses into TranscriptArtifact."""
+
+    def __init__(
+        self,
+        client: OpenAIClientLike,
+        *,
+        model: str,
+        language: str | None = None,
+        prompt: str | None = None,
+        max_retries_per_chunk: int = 2,
+        include_segment_timestamps: bool = True,
+    ) -> None:
+        if not model:
+            raise ValueError("model is required")
+        if max_retries_per_chunk < 0:
+            raise ValueError("max_retries_per_chunk must be >= 0")
+        self._client = client
+        self._model = model
+        self._language = language
+        self._prompt = prompt
+        self._max_retries_per_chunk = max_retries_per_chunk
+        self._include_segment_timestamps = include_segment_timestamps
+
+    def transcribe(self, chunks: ChunksArtifact) -> TranscriptArtifact:
+        if chunks.count != len(chunks.chunk_paths):
+            raise ProviderResponseError("ChunksArtifact count does not match chunk_paths length")
+
+        stitched_text_parts: list[str] = []
+        stitched_segments: list[TranscriptSegment] = []
+        selected_language = self._language
+        sum_chunk_durations = 0.0
+        has_any_duration = False
+        global_segment_index = 0
+
+        for chunk_index, chunk_path in enumerate(chunks.chunk_paths):
+            normalized = self._transcribe_chunk_with_retry(chunk_path)
+            if not selected_language and normalized.language:
+                selected_language = normalized.language
+
+            if normalized.text:
+                stitched_text_parts.append(normalized.text)
+
+            if normalized.duration_s is not None:
+                sum_chunk_durations += normalized.duration_s
+                has_any_duration = True
+
+            offset_s = float(chunk_index * chunks.chunk_seconds)
+            if normalized.segments:
+                for seg in normalized.segments:
+                    stitched_segments.append(
+                        TranscriptSegment(
+                            index=global_segment_index,
+                            text=seg.text,
+                            start_s=(seg.start_s + offset_s) if seg.start_s is not None else None,
+                            end_s=(seg.end_s + offset_s) if seg.end_s is not None else None,
+                            chunk_index=chunk_index,
+                        )
+                    )
+                    global_segment_index += 1
+            elif normalized.text:
+                stitched_segments.append(
+                    TranscriptSegment(
+                        index=global_segment_index,
+                        text=normalized.text,
+                        chunk_index=chunk_index,
+                    )
+                )
+                global_segment_index += 1
+
+        full_text = "\n".join(part for part in stitched_text_parts if part).strip()
+        if not full_text:
+            raise ProviderResponseError("OpenAI adapter produced an empty transcript")
+
+        timestamped_segments = [
+            seg for seg in stitched_segments if seg.start_s is not None or seg.end_s is not None
+        ]
+        timeline_start_s = (
+            min(seg.start_s for seg in timestamped_segments if seg.start_s is not None)
+            if any(seg.start_s is not None for seg in timestamped_segments)
+            else None
+        )
+        timeline_end_s = (
+            max(seg.end_s for seg in timestamped_segments if seg.end_s is not None)
+            if any(seg.end_s is not None for seg in timestamped_segments)
+            else None
+        )
+
+        duration_s: float | None = None
+        if timeline_start_s is not None and timeline_end_s is not None:
+            duration_s = max(0.0, timeline_end_s - timeline_start_s)
+        elif has_any_duration:
+            duration_s = sum_chunk_durations
+
+        timings = {
+            "segments_count": len(stitched_segments),
+            "timestamped_segments_count": len(timestamped_segments),
+            "timeline_start_s": timeline_start_s,
+            "timeline_end_s": timeline_end_s,
+        }
+
+        return TranscriptArtifact(
+            text=full_text,
+            provider="openai",
+            model=self._model,
+            chunk_count=chunks.count,
+            language=selected_language,
+            segments=stitched_segments or None,
+            duration_s=duration_s,
+            timings=timings,
+            meta={"chunk_seconds": chunks.chunk_seconds},
+        )
+
+    def _transcribe_chunk_with_retry(self, chunk_path: Path) -> _NormalizedChunkTranscript:
+        last_error: Exception | None = None
+        attempts = self._max_retries_per_chunk + 1
+        for attempt in range(1, attempts + 1):
+            try:
+                return self._transcribe_chunk(chunk_path)
+            except Exception as exc:  # pragma: no cover - exact provider exceptions vary
+                last_error = exc
+                if attempt >= attempts:
+                    break
+        message = f"OpenAI transcription failed for chunk {chunk_path} after {attempts} attempts"
+        raise ProviderRetryExhaustedError(message) from last_error
+
+    def _transcribe_chunk(self, chunk_path: Path) -> _NormalizedChunkTranscript:
+        request_kwargs: dict[str, Any] = {
+            "model": self._model,
+            "response_format": "verbose_json",
+        }
+        if self._language:
+            request_kwargs["language"] = self._language
+        if self._prompt:
+            request_kwargs["prompt"] = self._prompt
+        if self._include_segment_timestamps:
+            request_kwargs["timestamp_granularities"] = ["segment"]
+
+        with Path(chunk_path).open("rb") as fh:
+            response = self._client.audio.transcriptions.create(file=fh, **request_kwargs)
+
+        text = _coerce_text(_field(response, "text"))
+        segments = _normalize_segments(_field(response, "segments"))
+        if not text and segments:
+            text = " ".join(seg.text for seg in segments if seg.text).strip()
+        if not text:
+            raise ProviderResponseError("OpenAI transcription response missing text")
+
+        return _NormalizedChunkTranscript(
+            text=text,
+            language=_coerce_text(_field(response, "language")) or None,
+            duration_s=_float_or_none(_field(response, "duration")),
+            segments=segments,
+        )
+
+
+__all__ = ["OpenAIClientLike", "OpenAITranscriptionAdapter"]

--- a/src/adapters/transcription.py
+++ b/src/adapters/transcription.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from src.contracts.artifacts import ChunksArtifact, TranscriptArtifact
+
+
+class TranscriptionProvider(Protocol):
+    """Provider adapter boundary for chunked transcription."""
+
+    def transcribe(self, chunks: ChunksArtifact) -> TranscriptArtifact:
+        """Return a normalized transcript artifact for the given chunks."""
+
+
+__all__ = ["TranscriptionProvider"]

--- a/src/components/transcription.py
+++ b/src/components/transcription.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from src.adapters.transcription import TranscriptionProvider
+from src.contracts.artifacts import ChunksArtifact, TranscriptArtifact
+from src.contracts.errors import InputValidationError, TranscriptionError
+
+
+def _validate_chunks(chunks: ChunksArtifact) -> None:
+    if chunks.count != len(chunks.chunk_paths):
+        raise InputValidationError("chunks.count must match len(chunks.chunk_paths)")
+    if chunks.count == 0:
+        raise InputValidationError("at least one chunk is required for transcription")
+    for path in chunks.chunk_paths:
+        if not path.exists():
+            raise InputValidationError(f"chunk not found: {path}")
+        if not path.is_file():
+            raise InputValidationError(f"chunk is not a file: {path}")
+
+
+def transcribe_chunks(chunks: ChunksArtifact, provider: TranscriptionProvider) -> TranscriptArtifact:
+    """
+    Provider-agnostic transcription component.
+    Adapters own provider retries/response normalization/chunk stitching.
+    """
+    _validate_chunks(chunks)
+    transcript = provider.transcribe(chunks)
+    if transcript.chunk_count != chunks.count:
+        raise TranscriptionError(
+            f"provider returned chunk_count={transcript.chunk_count}, expected {chunks.count}"
+        )
+    return transcript
+
+
+__all__ = ["transcribe_chunks"]

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -1,4 +1,4 @@
-from .artifacts import AudioArtifact, ChunksArtifact, MinutesArtifact, TranscriptArtifact
+from .artifacts import AudioArtifact, ChunksArtifact, MinutesArtifact, TranscriptArtifact, TranscriptSegment
 from .errors import (
     ChunkingError,
     ComponentError,
@@ -7,6 +7,8 @@ from .errors import (
     InputValidationError,
     MinutesGenerationError,
     PipelineError,
+    ProviderResponseError,
+    ProviderRetryExhaustedError,
     TranscriptionError,
 )
 from .manifest import ArtifactRefs, Manifest, StepRecord, should_skip_step
@@ -15,6 +17,7 @@ __all__ = [
     "AudioArtifact",
     "ChunksArtifact",
     "TranscriptArtifact",
+    "TranscriptSegment",
     "MinutesArtifact",
     "ArtifactRefs",
     "Manifest",
@@ -28,4 +31,6 @@ __all__ = [
     "ChunkingError",
     "TranscriptionError",
     "MinutesGenerationError",
+    "ProviderResponseError",
+    "ProviderRetryExhaustedError",
 ]

--- a/src/contracts/artifacts.py
+++ b/src/contracts/artifacts.py
@@ -23,13 +23,25 @@ class ChunksArtifact:
 
 
 @dataclass(frozen=True, slots=True)
+class TranscriptSegment:
+    index: int
+    text: str
+    start_s: float | None = None
+    end_s: float | None = None
+    chunk_index: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class TranscriptArtifact:
     text: str
     provider: str
     model: str
     chunk_count: int
     language: str | None = None
+    segments: list[TranscriptSegment] | None = None
+    duration_s: float | None = None
     timings: dict[str, Any] | None = None
+    meta: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/contracts/errors.py
+++ b/src/contracts/errors.py
@@ -39,3 +39,11 @@ class ExternalToolError(FfmpegError):
 
 class ProviderError(TranscriptionError):
     """Compatibility alias for provider/API failures."""
+
+
+class ProviderResponseError(ProviderError):
+    """Raised when a provider returns an unexpected response shape."""
+
+
+class ProviderRetryExhaustedError(ProviderError):
+    """Raised when adapter-managed provider retries are exhausted."""

--- a/src/contracts/manifest.py
+++ b/src/contracts/manifest.py
@@ -75,6 +75,10 @@ class ArtifactRefs:
     transcript_provider: str | None = None
     transcript_model: str | None = None
     transcript_language: str | None = None
+    transcript_chunk_count: int | None = None
+    transcript_duration_s: float | None = None
+    transcript_segments_path: str | None = None
+    transcript_segments_count: int | None = None
 
     minutes_md_path: str | None = None
     minutes_sha256: str | None = None

--- a/tests/test_contract_defaults.py
+++ b/tests/test_contract_defaults.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 import unittest
 
-from src.contracts.artifacts import AudioArtifact, ChunksArtifact, MinutesArtifact, TranscriptArtifact
+from src.contracts.artifacts import (
+    AudioArtifact,
+    ChunksArtifact,
+    MinutesArtifact,
+    TranscriptArtifact,
+    TranscriptSegment,
+)
 
 
 class ArtifactDefaultsTests(unittest.TestCase):
@@ -16,7 +22,15 @@ class ArtifactDefaultsTests(unittest.TestCase):
 
         transcript = TranscriptArtifact(text="hi", provider="openai", model="gpt", chunk_count=1)
         self.assertIsNone(transcript.language)
+        self.assertIsNone(transcript.segments)
+        self.assertIsNone(transcript.duration_s)
         self.assertIsNone(transcript.timings)
+        self.assertIsNone(transcript.meta)
+
+        segment = TranscriptSegment(index=0, text="hello")
+        self.assertIsNone(segment.start_s)
+        self.assertIsNone(segment.end_s)
+        self.assertIsNone(segment.chunk_index)
 
         minutes = MinutesArtifact(markdown="# hi", model="gpt", prompt_version="v1")
         self.assertIsNone(minutes.tokens)

--- a/tests/test_openai_transcription_adapter.py
+++ b/tests/test_openai_transcription_adapter.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import unittest
+
+from src.adapters.openai_transcription import OpenAITranscriptionAdapter
+from src.components.transcription import transcribe_chunks
+from src.contracts.artifacts import ChunksArtifact, TranscriptArtifact
+from src.contracts.errors import ProviderRetryExhaustedError, TranscriptionError
+
+
+class _Obj:
+    def __init__(self, **kwargs) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class _FakeTranscriptionsAPI:
+    def __init__(self, responses: list[object]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs):
+        file_handle = kwargs["file"]
+        self.calls.append(
+            {
+                "filename": Path(file_handle.name).name,
+                "model": kwargs.get("model"),
+                "response_format": kwargs.get("response_format"),
+                "timestamp_granularities": kwargs.get("timestamp_granularities"),
+                "language": kwargs.get("language"),
+            }
+        )
+        next_item = self._responses.pop(0)
+        if isinstance(next_item, Exception):
+            raise next_item
+        return next_item
+
+
+class _FakeAudioAPI:
+    def __init__(self, transcriptions: _FakeTranscriptionsAPI) -> None:
+        self.transcriptions = transcriptions
+
+
+class _FakeClient:
+    def __init__(self, responses: list[object]) -> None:
+        self.audio = _FakeAudioAPI(_FakeTranscriptionsAPI(responses))
+
+
+class _WrongCountProvider:
+    def transcribe(self, chunks: ChunksArtifact) -> TranscriptArtifact:
+        return TranscriptArtifact(
+            text="bad",
+            provider="x",
+            model="m",
+            chunk_count=max(0, chunks.count - 1),
+        )
+
+
+class OpenAITranscriptionAdapterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_dir = Path("tests") / ".tmp_openai_transcription_adapter"
+        self.tmp_dir.mkdir(parents=True, exist_ok=True)
+        self.chunk_paths = []
+        for idx in range(2):
+            path = self.tmp_dir / f"chunk_{idx:04d}.wav"
+            path.write_bytes(b"RIFF")
+            self.chunk_paths.append(path)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _chunks_artifact(self) -> ChunksArtifact:
+        return ChunksArtifact(
+            dir=self.tmp_dir,
+            chunk_paths=list(self.chunk_paths),
+            chunk_seconds=30,
+            count=2,
+        )
+
+    def test_openai_adapter_retries_and_normalizes_stitched_transcript(self) -> None:
+        responses = [
+            RuntimeError("transient"),
+            {
+                "text": "hello world",
+                "language": "en",
+                "duration": 12.5,
+                "segments": [
+                    {"text": "hello", "start": 0.0, "end": 0.6},
+                    {"text": "world", "start": 0.7, "end": 1.2},
+                ],
+            },
+            _Obj(
+                text="second chunk",
+                language="en",
+                duration=10.0,
+                segments=[
+                    _Obj(text="second", start=0.2, end=0.8),
+                    _Obj(text="chunk", start=0.9, end=1.4),
+                ],
+            ),
+        ]
+        client = _FakeClient(responses)
+        adapter = OpenAITranscriptionAdapter(
+            client,
+            model="gpt-4o-mini-transcribe",
+            language="en",
+            max_retries_per_chunk=2,
+        )
+
+        transcript = transcribe_chunks(self._chunks_artifact(), adapter)
+
+        self.assertEqual(transcript.provider, "openai")
+        self.assertEqual(transcript.model, "gpt-4o-mini-transcribe")
+        self.assertEqual(transcript.chunk_count, 2)
+        self.assertEqual(transcript.language, "en")
+        self.assertEqual(transcript.text, "hello world\nsecond chunk")
+        self.assertIsNotNone(transcript.segments)
+        assert transcript.segments is not None
+        self.assertEqual(len(transcript.segments), 4)
+        self.assertEqual(transcript.segments[0].chunk_index, 0)
+        self.assertEqual(transcript.segments[2].chunk_index, 1)
+        self.assertAlmostEqual(transcript.segments[2].start_s or 0.0, 30.2, places=3)
+        self.assertAlmostEqual(transcript.segments[3].end_s or 0.0, 31.4, places=3)
+        self.assertAlmostEqual(transcript.duration_s or 0.0, 31.4, places=3)
+        self.assertEqual(transcript.timings["segments_count"], 4)
+        self.assertEqual(transcript.timings["timestamped_segments_count"], 4)
+        self.assertEqual(transcript.meta["chunk_seconds"], 30)
+
+        calls = client.audio.transcriptions.calls
+        self.assertEqual(len(calls), 3)  # first chunk retried once
+        self.assertEqual(calls[0]["filename"], "chunk_0000.wav")
+        self.assertEqual(calls[1]["filename"], "chunk_0000.wav")
+        self.assertEqual(calls[2]["filename"], "chunk_0001.wav")
+        self.assertEqual(calls[0]["response_format"], "verbose_json")
+        self.assertEqual(calls[0]["timestamp_granularities"], ["segment"])
+
+    def test_openai_adapter_raises_after_retry_exhausted(self) -> None:
+        client = _FakeClient([RuntimeError("down"), RuntimeError("still down")])
+        adapter = OpenAITranscriptionAdapter(client, model="gpt", max_retries_per_chunk=1)
+
+        with self.assertRaises(ProviderRetryExhaustedError):
+            adapter.transcribe(
+                ChunksArtifact(
+                    dir=self.tmp_dir,
+                    chunk_paths=[self.chunk_paths[0]],
+                    chunk_seconds=30,
+                    count=1,
+                )
+            )
+
+    def test_component_enforces_provider_contract_chunk_count(self) -> None:
+        with self.assertRaises(TranscriptionError):
+            transcribe_chunks(self._chunks_artifact(), _WrongCountProvider())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


## Summary
Implemented the PR 4 scaffolding for a provider abstraction layer and normalized transcript outputs. This introduces a clean provider boundary, ensures the pipeline never touches provider-specific response objects, and returns a single normalized `TranscriptArtifact` shape (including structured segments + metadata) regardless of transcription provider.

---

## What Changed

### Contracts / Artifacts
- Added a normalized transcript segment contract and expanded `TranscriptArtifact` to include structured `segments`, `duration`, and `meta`. *(artifacts.py: line 25)*

### Errors
- Added provider-specific transcription errors for malformed responses and retry exhaustion. *(errors.py: line 44)*

### Manifest Persistence
- Extended manifest transcript references to persist normalized transcript metadata (`chunk_count`, `duration`, `segments`). *(manifest.py: line 72)*

### Provider Boundary + Component
- Added provider boundary protocol `TranscriptionProvider`. *(transcription.py: line 8)*
- Added provider-agnostic transcription component wrapper intended for orchestrator use. *(transcription.py: line 20)*

### OpenAI Adapter (Initial Provider)
- Added an OpenAI-only adapter that:
  - hides provider response objects,
  - retries per chunk,
  - normalizes dict/object response formats,
  - stitches chunk text + timestamps into a single `TranscriptArtifact`.
  *(openai_transcription.py: line 88)*

### Exports
- Exported new adapter/contracts in package `__init__.py` files. *(__init__.py: line 3) and (__init__.py: line 1)*

---

## Tests

- Added OpenAI adapter normalization/retry tests. *(test_openai_transcription_adapter.py: line 61)*
- Updated contract defaults test for new transcript fields. *(test_contract_defaults.py: line 23)*

---

## Acceptance Criteria Coverage

- ✅ Pipeline code never touches provider-specific response objects (adapter hides all provider responses).
- ✅ `TranscriptArtifact` always includes `provider`, `model`, `chunk_count` (and now also `segments`, `duration`, `meta`).
- ✅ Provider/model naming normalization handled in adapter.
- ✅ Chunk stitching rules handled in adapter (text + timestamps stitched into one artifact).
- ✅ Timestamps normalized when available (via structured segments).
- ✅ Retries implemented inside adapter; orchestrator remains dumb.
- ✅ Contract and adapter behavior validated by tests.

---

## Validation

- Ran: `pytest.exe -q`
- Result: **16 passed**

---

## Note

The repo currently contains unrelated existing changes (e.g., `utils.py` deletion / other untracked files) that were **not modified** as part of this PR.