### PR TITLE
Add dumb pipeline orchestrator with step manifest persistence

### DIFF
--- a/src/contracts/manifest.py
+++ b/src/contracts/manifest.py
@@ -21,7 +21,7 @@ class StepRecord:
     attempts: int = 0
     meta: dict[str, Any] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
-    error: str | None = None
+    error: str | dict[str, Any] | None = None
     error_type: str | None = None
 
     def start(self, *, at_s: float | None = None) -> None:
@@ -34,7 +34,7 @@ class StepRecord:
         *,
         status: StepStatus,
         at_s: float | None = None,
-        error: str | None = None,
+        error: str | dict[str, Any] | None = None,
         error_type: str | None = None,
         meta: dict[str, Any] | None = None,
     ) -> None:

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,3 @@
+from .prediction_pipeline import ArtifactManifest, AudioNormalizer, PipelineConfig, run
+
+__all__ = ["ArtifactManifest", "AudioNormalizer", "PipelineConfig", "run"]

--- a/src/pipeline/io.py
+++ b/src/pipeline/io.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.contracts.manifest import Manifest
+
+
+@dataclass(frozen=True, slots=True)
+class PipelinePaths:
+    run_dir: Path
+    manifest_path: Path
+    normalized_audio_path: Path
+    chunks_dir: Path
+    transcript_path: Path
+    transcript_segments_path: Path
+    minutes_md_path: Path
+
+
+def build_pipeline_paths(
+    run_dir: Path,
+    *,
+    manifest_filename: str = "manifest.json",
+    normalized_audio_filename: str = "normalized.wav",
+    chunks_dirname: str = "chunks",
+    transcript_filename: str = "transcript.txt",
+    transcript_segments_filename: str = "transcript_segments.json",
+    minutes_filename: str = "minutes.md",
+) -> PipelinePaths:
+    run_dir = Path(run_dir)
+    return PipelinePaths(
+        run_dir=run_dir,
+        manifest_path=run_dir / manifest_filename,
+        normalized_audio_path=run_dir / normalized_audio_filename,
+        chunks_dir=run_dir / chunks_dirname,
+        transcript_path=run_dir / transcript_filename,
+        transcript_segments_path=run_dir / transcript_segments_filename,
+        minutes_md_path=run_dir / minutes_filename,
+    )
+
+
+def manifest_path_ref(path: Path, *, base_dir: Path) -> str:
+    path = Path(path)
+    base_dir = Path(base_dir)
+    try:
+        return path.relative_to(base_dir).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def write_text_file(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    _atomic_write_bytes(path, text.encode(encoding))
+
+
+def write_json_file(path: Path, data: Any) -> None:
+    payload = json.dumps(data, indent=2, sort_keys=True, default=str).encode("utf-8")
+    _atomic_write_bytes(path, payload)
+
+
+def persist_manifest(manifest: Manifest, path: Path) -> None:
+    manifest.touch()
+    write_json_file(path, manifest.to_dict())
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as tmp_file:
+            tmp_file.write(payload)
+            tmp_file.flush()
+            try:
+                os.fsync(tmp_file.fileno())
+            except OSError:
+                # Best-effort durability; some environments/sandboxes may not support fsync.
+                pass
+        os.replace(tmp_path, path)
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+__all__ = [
+    "PipelinePaths",
+    "build_pipeline_paths",
+    "manifest_path_ref",
+    "persist_manifest",
+    "write_json_file",
+    "write_text_file",
+]

--- a/src/pipeline/prediction_pipeline.py
+++ b/src/pipeline/prediction_pipeline.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import uuid4
+import traceback as tb
+
+from src.adapters.ffmpeg import FfmpegAdapter
+from src.adapters.transcription import TranscriptionProvider
+from src.components.chunking import chunk_audio
+from src.components.minutes import MinutesLLM, generate_minutes
+from src.components.transcription import transcribe_chunks
+from src.contracts.artifacts import AudioArtifact, ChunksArtifact, MinutesArtifact, TranscriptArtifact
+from src.contracts.errors import InputValidationError, PipelineError
+from src.contracts.manifest import Manifest, StepRecord
+from src.pipeline.io import build_pipeline_paths, manifest_path_ref, persist_manifest, write_json_file, write_text_file
+from src.utils.hashing import sha256_file
+
+
+ArtifactManifest = Manifest
+
+
+class AudioNormalizer(Protocol):
+    def normalize_audio(self, input_path: Path, output_path: Path) -> AudioArtifact:
+        """Return a normalized audio artifact written at output_path (or equivalent)."""
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineConfig:
+    output_dir: Path
+    normalizer: AudioNormalizer
+    ffmpeg: FfmpegAdapter
+    transcription_provider: TranscriptionProvider
+    minutes_llm: MinutesLLM
+    chunk_seconds: int
+    prompt_path: Path | None = None
+    prompt_version: str | None = None
+    minutes_extra_context: dict[str, str] | None = None
+    include_error_traceback: bool = False
+    run_id: str | None = None
+
+
+def run(input_path: Path, config: PipelineConfig) -> ArtifactManifest:
+    input_path = Path(input_path)
+    paths = build_pipeline_paths(config.output_dir)
+    manifest = Manifest(run_id=config.run_id or uuid4().hex)
+
+    normalized_audio: AudioArtifact | None = None
+    chunks: ChunksArtifact | None = None
+    transcript: TranscriptArtifact | None = None
+    minutes: MinutesArtifact | None = None
+
+    def fail_step(step: StepRecord, exc: Exception, *, step_context: dict[str, Any] | None = None) -> None:
+        error_context = {
+            "step": step.name,
+            "input_path": str(input_path),
+            "run_dir": str(paths.run_dir),
+            "step_context": _json_safe(step_context or {}),
+        }
+        error_payload: dict[str, Any] = {
+            "type": type(exc).__name__,
+            "message": str(exc),
+            "context": error_context,
+        }
+        if config.include_error_traceback:
+            error_payload["traceback"] = "".join(tb.format_exception(type(exc), exc, exc.__traceback__))
+
+        step.finish(
+            status="failed",
+            error=error_payload,
+            error_type=type(exc).__name__,
+            meta={"context": _json_safe(step_context or {})},
+        )
+        manifest.errors.append(f"{step.name}: {type(exc).__name__}: {exc}")
+        persist_manifest(manifest, paths.manifest_path)
+
+        if isinstance(exc, PipelineError):
+            raise exc
+        raise PipelineError(f"pipeline failed at step '{step.name}': {exc}") from exc
+
+    def complete_step(step: StepRecord, *, step_context: dict[str, Any] | None = None, artifacts: dict[str, Any] | None = None) -> None:
+        meta: dict[str, Any] = {}
+        if step_context:
+            meta["context"] = _json_safe(step_context)
+        if artifacts:
+            meta["artifacts"] = _json_safe(artifacts)
+        step.finish(status="success", meta=meta or None)
+        persist_manifest(manifest, paths.manifest_path)
+
+    def start_step(name: str, *, step_context: dict[str, Any] | None = None) -> StepRecord:
+        step = manifest.ensure_step(name)
+        step.start()
+        if step_context:
+            step.meta["context"] = _json_safe(step_context)
+        return step
+
+    # 1. validate
+    validate_context = {"output_dir": str(paths.run_dir)}
+    step = start_step("validate", step_context=validate_context)
+    try:
+        if not input_path.exists():
+            raise InputValidationError(f"input not found: {input_path}")
+        if not input_path.is_file():
+            raise InputValidationError(f"input is not a file: {input_path}")
+        if paths.run_dir.exists() and not paths.run_dir.is_dir():
+            raise InputValidationError(f"output_dir is not a directory: {paths.run_dir}")
+
+        paths.run_dir.mkdir(parents=True, exist_ok=True)
+        manifest.artifacts.input_path = str(input_path)
+        manifest.input_sha256 = sha256_file(input_path)
+        manifest.artifacts.input_sha256 = manifest.input_sha256
+
+        complete_step(
+            step,
+            step_context=validate_context,
+            artifacts={
+                "input_path": manifest.artifacts.input_path,
+                "input_sha256": manifest.artifacts.input_sha256,
+            },
+        )
+    except Exception as exc:
+        fail_step(step, exc, step_context=validate_context)
+
+    # 2. normalize
+    normalize_context = {
+        "normalizer": type(config.normalizer).__name__,
+        "output_path": str(paths.normalized_audio_path),
+    }
+    step = start_step("normalize", step_context=normalize_context)
+    try:
+        normalized_audio = config.normalizer.normalize_audio(input_path, paths.normalized_audio_path)
+        manifest.artifacts.normalized_audio_path = manifest_path_ref(normalized_audio.path, base_dir=paths.run_dir)
+        manifest.artifacts.normalized_audio_sha256 = normalized_audio.sha256
+
+        complete_step(
+            step,
+            step_context=normalize_context,
+            artifacts={
+                "normalized_audio_path": manifest.artifacts.normalized_audio_path,
+                "normalized_audio_sha256": manifest.artifacts.normalized_audio_sha256,
+            },
+        )
+    except Exception as exc:
+        fail_step(step, exc, step_context=normalize_context)
+
+    # 3. chunk
+    chunk_context = {
+        "chunk_seconds": config.chunk_seconds,
+        "ffmpeg_adapter": type(config.ffmpeg).__name__,
+        "chunks_dir": str(paths.chunks_dir),
+    }
+    step = start_step("chunk", step_context=chunk_context)
+    try:
+        if normalized_audio is None:
+            raise PipelineError("normalize step did not produce an audio artifact")
+        chunks = chunk_audio(
+            normalized_audio=normalized_audio,
+            chunk_seconds=config.chunk_seconds,
+            out_dir=paths.chunks_dir,
+            ffmpeg=config.ffmpeg,
+        )
+        manifest.artifacts.chunks_dir = manifest_path_ref(chunks.dir, base_dir=paths.run_dir)
+        manifest.artifacts.chunk_paths = [manifest_path_ref(path, base_dir=paths.run_dir) for path in chunks.chunk_paths]
+        manifest.artifacts.chunk_seconds = chunks.chunk_seconds
+
+        complete_step(
+            step,
+            step_context=chunk_context,
+            artifacts={
+                "chunks_dir": manifest.artifacts.chunks_dir,
+                "chunk_paths": manifest.artifacts.chunk_paths,
+                "chunk_seconds": manifest.artifacts.chunk_seconds,
+            },
+        )
+    except Exception as exc:
+        fail_step(step, exc, step_context=chunk_context)
+
+    # 4. transcribe
+    transcribe_context = {
+        "provider": type(config.transcription_provider).__name__,
+        "chunk_count": chunks.count if chunks is not None else None,
+    }
+    step = start_step("transcribe", step_context=transcribe_context)
+    try:
+        if chunks is None:
+            raise PipelineError("chunk step did not produce chunk artifacts")
+        transcript = transcribe_chunks(chunks, config.transcription_provider)
+        manifest.artifacts.transcript_text = transcript.text
+        manifest.artifacts.transcript_provider = transcript.provider
+        manifest.artifacts.transcript_model = transcript.model
+        manifest.artifacts.transcript_language = transcript.language
+        manifest.artifacts.transcript_chunk_count = transcript.chunk_count
+        manifest.artifacts.transcript_duration_s = transcript.duration_s
+
+        complete_step(
+            step,
+            step_context=transcribe_context,
+            artifacts={
+                "transcript_provider": manifest.artifacts.transcript_provider,
+                "transcript_model": manifest.artifacts.transcript_model,
+                "transcript_chunk_count": manifest.artifacts.transcript_chunk_count,
+            },
+        )
+    except Exception as exc:
+        fail_step(step, exc, step_context=transcribe_context)
+
+    # 5. generate
+    generate_context = {
+        "llm": type(config.minutes_llm).__name__,
+        "prompt_path": str(config.prompt_path) if config.prompt_path is not None else None,
+        "prompt_version": config.prompt_version,
+    }
+    step = start_step("generate", step_context=generate_context)
+    try:
+        if transcript is None:
+            raise PipelineError("transcribe step did not produce a transcript artifact")
+        generate_kwargs: dict[str, Any] = {
+            "llm": config.minutes_llm,
+            "prompt_version": config.prompt_version,
+            "extra_context": config.minutes_extra_context,
+        }
+        if config.prompt_path is not None:
+            generate_kwargs["prompt_path"] = config.prompt_path
+
+        minutes = generate_minutes(transcript, **generate_kwargs)
+        manifest.artifacts.minutes_markdown = minutes.markdown
+        manifest.artifacts.minutes_model = minutes.model
+        manifest.artifacts.minutes_prompt_version = minutes.prompt_version
+        if minutes.meta:
+            prompt_path_value = minutes.meta.get("prompt_path")
+            prompt_hash_value = minutes.meta.get("prompt_hash")
+            if prompt_path_value is not None:
+                manifest.artifacts.minutes_prompt_path = str(prompt_path_value)
+            if prompt_hash_value is not None:
+                manifest.artifacts.minutes_prompt_hash = str(prompt_hash_value)
+
+        complete_step(
+            step,
+            step_context=generate_context,
+            artifacts={
+                "minutes_model": manifest.artifacts.minutes_model,
+                "minutes_prompt_version": manifest.artifacts.minutes_prompt_version,
+                "minutes_prompt_path": manifest.artifacts.minutes_prompt_path,
+            },
+        )
+    except Exception as exc:
+        fail_step(step, exc, step_context=generate_context)
+
+    # 6. write outputs
+    write_context = {
+        "transcript_path": str(paths.transcript_path),
+        "transcript_segments_path": str(paths.transcript_segments_path),
+        "minutes_md_path": str(paths.minutes_md_path),
+    }
+    step = start_step("write_outputs", step_context=write_context)
+    try:
+        if transcript is None:
+            raise PipelineError("write_outputs requires a transcript artifact")
+        if minutes is None:
+            raise PipelineError("write_outputs requires a minutes artifact")
+
+        write_text_file(paths.transcript_path, transcript.text.rstrip() + "\n")
+        manifest.artifacts.transcript_path = manifest_path_ref(paths.transcript_path, base_dir=paths.run_dir)
+        manifest.artifacts.transcript_sha256 = sha256_file(paths.transcript_path)
+
+        if transcript.segments is not None:
+            segments_payload = [asdict(segment) for segment in transcript.segments]
+            write_json_file(paths.transcript_segments_path, segments_payload)
+            manifest.artifacts.transcript_segments_path = manifest_path_ref(paths.transcript_segments_path, base_dir=paths.run_dir)
+            manifest.artifacts.transcript_segments_count = len(transcript.segments)
+
+        write_text_file(paths.minutes_md_path, minutes.markdown.rstrip() + "\n")
+        manifest.artifacts.minutes_md_path = manifest_path_ref(paths.minutes_md_path, base_dir=paths.run_dir)
+        manifest.artifacts.minutes_sha256 = sha256_file(paths.minutes_md_path)
+
+        complete_step(
+            step,
+            step_context=write_context,
+            artifacts={
+                "transcript_path": manifest.artifacts.transcript_path,
+                "transcript_sha256": manifest.artifacts.transcript_sha256,
+                "minutes_md_path": manifest.artifacts.minutes_md_path,
+                "minutes_sha256": manifest.artifacts.minutes_sha256,
+                "transcript_segments_path": manifest.artifacts.transcript_segments_path,
+            },
+        )
+    except Exception as exc:
+        fail_step(step, exc, step_context=write_context)
+
+    return manifest
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    return repr(value)
+
+
+__all__ = [
+    "ArtifactManifest",
+    "AudioNormalizer",
+    "PipelineConfig",
+    "run",
+]

--- a/tests/test_prediction_pipeline.py
+++ b/tests/test_prediction_pipeline.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from src.contracts.artifacts import AudioArtifact, MinutesArtifact, TranscriptArtifact, TranscriptSegment
+from src.contracts.errors import PipelineError, TranscriptionError
+from src.contracts.manifest import Manifest
+from src.pipeline.prediction_pipeline import PipelineConfig, run
+from src.utils.hashing import sha256_file
+
+
+class _FakeNormalizer:
+    def normalize_audio(self, input_path: Path, output_path: Path) -> AudioArtifact:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(input_path.read_bytes())
+        return AudioArtifact(path=output_path, sha256=sha256_file(output_path), duration_s=12.3, sample_rate=16000, channels=1)
+
+
+class _FakeFfmpeg:
+    def chunk_audio(self, input_audio: str | Path, chunks_dir: str | Path, chunk_seconds: int) -> None:
+        out_dir = Path(chunks_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(2):
+            (out_dir / f"chunk_{i:04d}.wav").write_bytes(f"chunk-{i}-{chunk_seconds}".encode("utf-8"))
+
+
+class _ManifestAwareProvider:
+    def __init__(self, manifest_path: Path, *, fail: bool = False) -> None:
+        self.manifest_path = manifest_path
+        self.fail = fail
+        self.saw_chunk_success_in_manifest = False
+
+    def transcribe(self, chunks) -> TranscriptArtifact:  # type: ignore[no-untyped-def]
+        if self.manifest_path.exists():
+            manifest = Manifest.read_json(self.manifest_path)
+            chunk_step = manifest.steps.get("chunk")
+            self.saw_chunk_success_in_manifest = chunk_step is not None and chunk_step.status == "success"
+
+        if self.fail:
+            raise TranscriptionError("provider misconfig")
+
+        return TranscriptArtifact(
+            text="hello world",
+            provider="fake-provider",
+            model="fake-transcriber",
+            chunk_count=chunks.count,
+            language="en",
+            duration_s=12.3,
+            segments=[
+                TranscriptSegment(index=0, text="hello", start_s=0.0, end_s=1.0, chunk_index=0),
+                TranscriptSegment(index=1, text="world", start_s=1.0, end_s=2.0, chunk_index=0),
+            ],
+        )
+
+
+class _FakeMinutesLLM:
+    def generate_minutes(self, transcript, *, prompt: str, extra_context=None) -> MinutesArtifact:  # type: ignore[no-untyped-def]
+        return MinutesArtifact(
+            markdown="# Minutes\n\n- hello world",
+            model="fake-minutes-model",
+            meta={"request_id": "req_123"},
+        )
+
+
+class PredictionPipelineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_dir = Path(self._tmp.name)
+        self.input_path = self.tmp_dir / "input.mp3"
+        self.input_path.write_bytes(b"fake-audio")
+        self.prompt_path = self.tmp_dir / "minutes_prompt.md"
+        self.prompt_path.write_text("Write concise minutes in Markdown.", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _config(self, output_dir: Path, provider: _ManifestAwareProvider, *, include_error_traceback: bool = False) -> PipelineConfig:
+        return PipelineConfig(
+            output_dir=output_dir,
+            normalizer=_FakeNormalizer(),
+            ffmpeg=_FakeFfmpeg(),
+            transcription_provider=provider,
+            minutes_llm=_FakeMinutesLLM(),
+            chunk_seconds=30,
+            prompt_path=self.prompt_path,
+            prompt_version="v-test",
+            include_error_traceback=include_error_traceback,
+        )
+
+    def test_run_success_persists_manifest_and_outputs(self) -> None:
+        output_dir = self.tmp_dir / "artifacts"
+        provider = _ManifestAwareProvider(output_dir / "manifest.json")
+
+        manifest = run(self.input_path, self._config(output_dir, provider))
+
+        self.assertTrue(provider.saw_chunk_success_in_manifest)
+        self.assertEqual(manifest.steps["validate"].status, "success")
+        self.assertEqual(manifest.steps["normalize"].status, "success")
+        self.assertEqual(manifest.steps["chunk"].status, "success")
+        self.assertEqual(manifest.steps["transcribe"].status, "success")
+        self.assertEqual(manifest.steps["generate"].status, "success")
+        self.assertEqual(manifest.steps["write_outputs"].status, "success")
+
+        manifest_path = output_dir / "manifest.json"
+        self.assertTrue(manifest_path.exists())
+        persisted = Manifest.read_json(manifest_path)
+        self.assertEqual(persisted.steps["write_outputs"].status, "success")
+        self.assertEqual(persisted.artifacts.transcript_path, "transcript.txt")
+        self.assertEqual(persisted.artifacts.minutes_md_path, "minutes.md")
+        self.assertEqual(persisted.artifacts.transcript_segments_path, "transcript_segments.json")
+        self.assertIsNotNone(persisted.artifacts.transcript_sha256)
+        self.assertIsNotNone(persisted.artifacts.minutes_sha256)
+        self.assertEqual((output_dir / "minutes.md").read_text(encoding="utf-8").strip(), "# Minutes\n\n- hello world")
+
+    def test_run_failure_persists_failed_step_error_context(self) -> None:
+        output_dir = self.tmp_dir / "artifacts_fail"
+        provider = _ManifestAwareProvider(output_dir / "manifest.json", fail=True)
+
+        with self.assertRaises(PipelineError):
+            run(
+                self.input_path,
+                self._config(output_dir, provider, include_error_traceback=True),
+            )
+
+        manifest_path = output_dir / "manifest.json"
+        self.assertTrue(manifest_path.exists())
+        persisted = Manifest.read_json(manifest_path)
+
+        self.assertTrue(provider.saw_chunk_success_in_manifest)
+        self.assertEqual(persisted.steps["validate"].status, "success")
+        self.assertEqual(persisted.steps["normalize"].status, "success")
+        self.assertEqual(persisted.steps["chunk"].status, "success")
+        self.assertEqual(persisted.steps["transcribe"].status, "failed")
+        self.assertNotIn("write_outputs", persisted.steps)
+
+        error = persisted.steps["transcribe"].error
+        self.assertIsInstance(error, dict)
+        assert isinstance(error, dict)
+        self.assertEqual(error["type"], "TranscriptionError")
+        self.assertIn("provider misconfig", error["message"])
+        self.assertIn("context", error)
+        self.assertEqual(error["context"]["step"], "transcribe")
+        self.assertIn("traceback", error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Summary
Implements PR 6 by adding a “dumb” pipeline orchestrator that strictly sequences the workflow and persists `manifest.json` **after every step** (success or failure). Also introduces atomic-ish write utilities, structured step error payloads (backward-compatible), and tests that verify persistence behavior across success and failure paths.

## What Changed
- Added dumb orchestrator `run(input_path, config)` with fixed sequencing and per-step manifest persistence in `src/pipeline/prediction_pipeline.py` (line 44).
- Added atomic-ish manifest/output write helpers in `src/pipeline/io.py` (line 24) and `src/pipeline/io.py` (line 64).
- Added pipeline exports in `src/pipeline/__init__.py` (line 1).
- Extended `StepRecord.error` to support structured error payloads (`type`/`message`/`context`/`traceback`) while remaining backward-compatible in `src/manifest.py` (line 24) and `src/manifest.py` (line 37).
- Added tests covering success + failure persistence behavior in `tests/test_prediction_pipeline.py` (line 92) and `tests/test_prediction_pipeline.py` (line 117).

## Behavior
- Steps are strictly sequenced:
  `validate -> normalize -> chunk -> transcribe -> generate -> write_outputs`
  (manifest step key uses `write_outputs`).
- After **every** step (success or failure), `manifest.json` is persisted immediately.
- On failure:
  - the failing step is marked `failed`
  - `step.error` is recorded as a structured dict
  - `manifest.json` is written
  - a `PipelineError` is raised

## Acceptance Criteria
- ✅ Orchestrator contains **zero** ffmpeg decision logic, prompt shaping, or retry loops.
- ✅ On failure, manifest includes **step error + context**, and is **persisted**.

## Verification
- Ran full suite: `PYTHONPATH=. pytest -q`
- Result: **20 passed**

## Notes
- Left unrelated local changes untouched (`utils.py`, `process.py`, existing untracked `test_ffmpeg_cmds.py`).