### PR TITLE
Add CLI entrypoint for pipeline runner

### DIFF
--- a/run_minutes.py
+++ b/run_minutes.py
@@ -1,0 +1,6 @@
+from src.cli.run_minutes import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,2 @@
+"""CLI entrypoints for the Minutes pipeline."""
+

--- a/src/cli/run_minutes.py
+++ b/src/cli/run_minutes.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from src.adapters.ffmpeg import build_ffmpeg_chunk_cmd, build_ffmpeg_normalize_cmd
+from src.adapters.openai_transcription import OpenAITranscriptionAdapter
+from src.components.minutes import MinutesLLM
+from src.contracts.artifacts import AudioArtifact, MinutesArtifact, TranscriptArtifact
+from src.contracts.errors import FfmpegError
+from src.pipeline.io import build_pipeline_paths
+from src.pipeline.prediction_pipeline import PipelineConfig, run as run_pipeline
+from src.utils.hashing import sha256_file
+
+
+type Argv = Sequence[str]
+
+
+@dataclass(frozen=True, slots=True)
+class CliRunResult:
+    manifest_path: Path
+    output_dir: Path
+
+
+class _FfmpegChunkAdapter:
+    def chunk_audio(self, input_audio: str | Path, chunks_dir: str | Path, chunk_seconds: int) -> None:
+        cmd = build_ffmpeg_chunk_cmd(input_audio, chunks_dir, chunk_seconds)
+        _run_ffmpeg_or_raise(cmd, "ffmpeg chunking failed")
+
+
+class _FfmpegAudioNormalizer:
+    def __init__(self, *, sample_rate: int, channels: int = 1) -> None:
+        self._sample_rate = sample_rate
+        self._channels = channels
+
+    def normalize_audio(self, input_path: Path, output_path: Path) -> AudioArtifact:
+        cmd = build_ffmpeg_normalize_cmd(
+            input_path=input_path,
+            output_path=output_path,
+            sample_rate=self._sample_rate,
+            channels=self._channels,
+        )
+        _run_ffmpeg_or_raise(cmd, "ffmpeg normalization failed")
+        if not output_path.exists() or not output_path.is_file():
+            raise FfmpegError(f"ffmpeg did not produce normalized audio: {output_path}")
+        return AudioArtifact(
+            path=output_path,
+            sha256=sha256_file(output_path),
+            sample_rate=self._sample_rate,
+            channels=self._channels,
+        )
+
+
+class _OpenAIMinutesLLM(MinutesLLM):
+    def __init__(self, client: Any, *, model: str) -> None:
+        if not model:
+            raise ValueError("minutes model is required")
+        self._client = client
+        self._model = model
+
+    def generate_minutes(
+        self,
+        transcript: TranscriptArtifact,
+        *,
+        prompt: str,
+        extra_context: dict[str, str] | None = None,
+    ) -> MinutesArtifact:
+        message = _build_minutes_message(prompt=prompt, transcript=transcript.text, extra_context=extra_context)
+        text = _call_openai_text(client=self._client, model=self._model, message=message)
+        return MinutesArtifact(markdown=text, model=self._model)
+
+
+def _build_minutes_message(*, prompt: str, transcript: str, extra_context: dict[str, str] | None) -> str:
+    parts = [prompt.strip(), "", "Transcript:", transcript.strip()]
+    if extra_context:
+        parts.extend(["", "Extra context:"])
+        for key, value in sorted(extra_context.items()):
+            parts.append(f"- {key}: {value}")
+    return "\n".join(parts).strip()
+
+
+def _call_openai_text(*, client: Any, model: str, message: str) -> str:
+    responses_api = getattr(client, "responses", None)
+    if responses_api is not None and hasattr(responses_api, "create"):
+        response = responses_api.create(model=model, input=message)
+        output_text = getattr(response, "output_text", None)
+        if isinstance(output_text, str) and output_text.strip():
+            return output_text.strip()
+
+    chat_api = getattr(client, "chat", None)
+    completions_api = getattr(chat_api, "completions", None) if chat_api is not None else None
+    if completions_api is not None and hasattr(completions_api, "create"):
+        response = completions_api.create(
+            model=model,
+            messages=[{"role": "user", "content": message}],
+        )
+        text = _extract_chat_completion_text(response)
+        if text:
+            return text
+
+    raise RuntimeError("unable to extract text from OpenAI response")
+
+
+def _extract_chat_completion_text(response: Any) -> str:
+    choices = getattr(response, "choices", None)
+    if not isinstance(choices, list) or not choices:
+        return ""
+    first_choice = choices[0]
+    message = getattr(first_choice, "message", None)
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        chunks: list[str] = []
+        for item in content:
+            text = _field(item, "text")
+            if text:
+                chunks.append(str(text))
+        return "\n".join(chunks).strip()
+    return ""
+
+
+def _field(obj: Any, name: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _run_ffmpeg_or_raise(cmd: Sequence[str], fallback_message: str) -> None:
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode == 0:
+        return
+    message = completed.stderr.strip() or completed.stdout.strip() or fallback_message
+    raise FfmpegError(message)
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be > 0")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid int value: {value}") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
+
+
+def _kv_pair(value: str) -> str:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("expected KEY=VALUE")
+    key, _, raw_value = value.partition("=")
+    if not key.strip():
+        raise argparse.ArgumentTypeError("context key must not be empty")
+    return f"{key}={raw_value}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Minutes pipeline.")
+    parser.add_argument("--input", dest="input_path", type=Path, required=True, help="Input audio file path.")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Output artifacts directory.")
+    parser.add_argument("--provider", choices=["openai"], required=True, help="Transcription provider.")
+    parser.add_argument("--model", required=True, help="Transcription model (for the selected provider).")
+    parser.add_argument("--chunk-seconds", type=_positive_int, required=True, help="Chunk size in seconds.")
+    parser.add_argument("--sample-rate", type=_positive_int, default=16000, help="Normalized WAV sample rate.")
+    parser.add_argument("--channels", type=_positive_int, default=1, help="Normalized WAV channel count.")
+    parser.add_argument("--language", default=None, help="Transcription language code (e.g. en).")
+    parser.add_argument("--transcription-prompt", default=None, help="Optional provider prompt for transcription.")
+    parser.add_argument(
+        "--transcription-max-retries",
+        type=_nonnegative_int,
+        default=2,
+        help="Provider retries per chunk (>= 0).",
+    )
+    parser.add_argument("--minutes-model", default="gpt-4o-mini", help="Minutes generation model.")
+    parser.add_argument("--prompt-path", type=Path, default=None, help="Minutes prompt file path.")
+    parser.add_argument("--prompt-version", default=None, help="Prompt version recorded in the manifest.")
+    parser.add_argument(
+        "--minutes-extra-context",
+        action="append",
+        type=_kv_pair,
+        default=[],
+        help="Additional minutes context as KEY=VALUE (repeatable).",
+    )
+    parser.add_argument("--run-id", default=None, help="Optional deterministic run identifier.")
+    parser.add_argument(
+        "--include-error-traceback",
+        action="store_true",
+        help="Persist traceback details in manifest step errors.",
+    )
+    return parser
+
+
+def parse_args(argv: Argv | None = None) -> argparse.Namespace:
+    return build_parser().parse_args(list(argv) if argv is not None else None)
+
+
+def build_pipeline_config(
+    args: argparse.Namespace,
+    *,
+    normalizer: Any,
+    ffmpeg: Any,
+    transcription_provider: Any,
+    minutes_llm: Any,
+) -> PipelineConfig:
+    return PipelineConfig(
+        output_dir=Path(args.output_dir),
+        normalizer=normalizer,
+        ffmpeg=ffmpeg,
+        transcription_provider=transcription_provider,
+        minutes_llm=minutes_llm,
+        chunk_seconds=int(args.chunk_seconds),
+        prompt_path=Path(args.prompt_path) if args.prompt_path is not None else None,
+        prompt_version=args.prompt_version,
+        minutes_extra_context=_minutes_extra_context_dict(args.minutes_extra_context),
+        include_error_traceback=bool(args.include_error_traceback),
+        run_id=args.run_id,
+    )
+
+
+def _minutes_extra_context_dict(entries: list[str]) -> dict[str, str] | None:
+    if not entries:
+        return None
+    parsed: dict[str, str] = {}
+    for entry in entries:
+        key, _, value = entry.partition("=")
+        parsed[key] = value
+    return parsed or None
+
+
+def _load_openai_client() -> Any:
+    try:
+        from openai import OpenAI
+    except ImportError as exc:  # pragma: no cover - depends on local runtime
+        raise RuntimeError("The 'openai' package is required to use the CLI (pip install openai).") from exc
+    return OpenAI()
+
+
+def _build_runtime_dependencies(args: argparse.Namespace) -> dict[str, Any]:
+    if args.provider != "openai":
+        raise ValueError(f"unsupported provider: {args.provider}")
+
+    client = _load_openai_client()
+    return {
+        "normalizer": _FfmpegAudioNormalizer(sample_rate=int(args.sample_rate), channels=int(args.channels)),
+        "ffmpeg": _FfmpegChunkAdapter(),
+        "transcription_provider": OpenAITranscriptionAdapter(
+            client,
+            model=args.model,
+            language=args.language,
+            prompt=args.transcription_prompt,
+            max_retries_per_chunk=int(args.transcription_max_retries),
+        ),
+        "minutes_llm": _OpenAIMinutesLLM(client, model=args.minutes_model),
+    }
+
+
+def run_from_args(args: argparse.Namespace) -> CliRunResult:
+    deps = _build_runtime_dependencies(args)
+    config = build_pipeline_config(args, **deps)
+    run_pipeline(Path(args.input_path), config)
+    paths = build_pipeline_paths(Path(args.output_dir))
+    return CliRunResult(manifest_path=paths.manifest_path, output_dir=paths.run_dir)
+
+
+def main(argv: Argv | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        result = run_from_args(args)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"manifest_path={result.manifest_path}")
+    print(f"output_dir={result.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.cli import run_minutes as cli
+from src.pipeline.prediction_pipeline import PipelineConfig
+
+
+def test_parse_args_maps_cli_flags() -> None:
+    args = cli.parse_args(
+        [
+            "--input",
+            "audio.wav",
+            "--output-dir",
+            "outputs",
+            "--provider",
+            "openai",
+            "--model",
+            "whisper-1",
+            "--chunk-seconds",
+            "30",
+            "--sample-rate",
+            "16000",
+            "--language",
+            "en",
+            "--minutes-extra-context",
+            "team=platform",
+            "--minutes-extra-context",
+            "timezone=UTC",
+            "--prompt-version",
+            "v1",
+            "--include-error-traceback",
+        ]
+    )
+
+    assert args.input_path == Path("audio.wav")
+    assert args.output_dir == Path("outputs")
+    assert args.provider == "openai"
+    assert args.model == "whisper-1"
+    assert args.chunk_seconds == 30
+    assert args.sample_rate == 16000
+    assert args.language == "en"
+    assert args.prompt_version == "v1"
+    assert args.minutes_extra_context == ["team=platform", "timezone=UTC"]
+    assert args.include_error_traceback is True
+
+
+def test_build_pipeline_config_maps_pipeline_fields() -> None:
+    args = cli.parse_args(
+        [
+            "--input",
+            "audio.wav",
+            "--output-dir",
+            "outputs",
+            "--provider",
+            "openai",
+            "--model",
+            "whisper-1",
+            "--chunk-seconds",
+            "45",
+            "--prompt-path",
+            "prompt.md",
+            "--prompt-version",
+            "v2",
+            "--run-id",
+            "run_123",
+            "--minutes-extra-context",
+            "project=minutes",
+        ]
+    )
+
+    normalizer = object()
+    ffmpeg = object()
+    provider = object()
+    minutes_llm = object()
+    config = cli.build_pipeline_config(
+        args,
+        normalizer=normalizer,
+        ffmpeg=ffmpeg,
+        transcription_provider=provider,
+        minutes_llm=minutes_llm,
+    )
+
+    assert isinstance(config, PipelineConfig)
+    assert config.output_dir == Path("outputs")
+    assert config.normalizer is normalizer
+    assert config.ffmpeg is ffmpeg
+    assert config.transcription_provider is provider
+    assert config.minutes_llm is minutes_llm
+    assert config.chunk_seconds == 45
+    assert config.prompt_path == Path("prompt.md")
+    assert config.prompt_version == "v2"
+    assert config.run_id == "run_123"
+    assert config.minutes_extra_context == {"project": "minutes"}
+    assert config.include_error_traceback is False
+
+
+def test_run_from_args_delegates_to_orchestrator_and_returns_deterministic_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_build_runtime_dependencies(args):  # type: ignore[no-untyped-def]
+        captured["provider"] = args.provider
+        captured["model"] = args.model
+        captured["language"] = args.language
+        captured["sample_rate"] = args.sample_rate
+        return {
+            "normalizer": object(),
+            "ffmpeg": object(),
+            "transcription_provider": object(),
+            "minutes_llm": object(),
+        }
+
+    def fake_run_pipeline(input_path, config):  # type: ignore[no-untyped-def]
+        captured["input_path"] = input_path
+        captured["config"] = config
+        return object()
+
+    monkeypatch.setattr(cli, "_build_runtime_dependencies", fake_build_runtime_dependencies)
+    monkeypatch.setattr(cli, "run_pipeline", fake_run_pipeline)
+
+    args = cli.parse_args(
+        [
+            "--input",
+            "audio.wav",
+            "--output-dir",
+            "outputs",
+            "--provider",
+            "openai",
+            "--model",
+            "whisper-1",
+            "--chunk-seconds",
+            "30",
+            "--sample-rate",
+            "16000",
+            "--language",
+            "en",
+        ]
+    )
+    result = cli.run_from_args(args)
+
+    assert captured["provider"] == "openai"
+    assert captured["model"] == "whisper-1"
+    assert captured["language"] == "en"
+    assert captured["sample_rate"] == 16000
+    assert captured["input_path"] == Path("audio.wav")
+    assert isinstance(captured["config"], PipelineConfig)
+    assert result.manifest_path == Path("outputs") / "manifest.json"
+    assert result.output_dir == Path("outputs")
+
+
+def test_main_success_prints_paths_and_returns_zero(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(
+        cli,
+        "run_from_args",
+        lambda args: cli.CliRunResult(manifest_path=Path("outputs/manifest.json"), output_dir=Path("outputs")),
+    )
+
+    exit_code = cli.main(
+        [
+            "--input",
+            "audio.wav",
+            "--output-dir",
+            "outputs",
+            "--provider",
+            "openai",
+            "--model",
+            "whisper-1",
+            "--chunk-seconds",
+            "30",
+        ]
+    )
+    out = capsys.readouterr()
+
+    assert exit_code == 0
+    assert out.err == ""
+    assert out.out.splitlines() == [
+        f"manifest_path={Path('outputs') / 'manifest.json'}",
+        "output_dir=outputs",
+    ]
+
+
+def test_main_failure_returns_nonzero(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def raise_error(args):  # type: ignore[no-untyped-def]
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli, "run_from_args", raise_error)
+
+    exit_code = cli.main(
+        [
+            "--input",
+            "audio.wav",
+            "--output-dir",
+            "outputs",
+            "--provider",
+            "openai",
+            "--model",
+            "whisper-1",
+            "--chunk-seconds",
+            "30",
+        ]
+    )
+    out = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "error: boom" in out.err


### PR DESCRIPTION


## Summary

Implements a thin CLI entrypoint for the Minutes pipeline with full test coverage.

The CLI:

- Parses flags using `argparse`
- Constructs `PipelineConfig`
- Delegates execution to `src.pipeline.prediction_pipeline.run`
- Prints deterministic output paths
- Exits non-zero on failure

The CLI contains **no orchestration or business logic**.

---

## What Changed

### CLI Module

Added CLI module at:

- `run_minutes.py` (line 170)

Includes:

- Flag parsing (`argparse`)
- `PipelineConfig` construction (`run_minutes.py` line 210)
- Orchestrator delegation to `src.pipeline.prediction_pipeline.run` (`run_minutes.py` line 270)
- Deterministic manifest + output directory printing
- Non-zero exit handling on failure (`run_minutes.py` line 278)

---

### Executable Shim

Added root executable shim:

- `run_minutes.py` (line 1)

Enables:

```bash
python run_minutes.py ...